### PR TITLE
Bug sweep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ obj/
 .idea/
 *.received.*
 nugets/
+BenchmarkDotNet.Artifacts/

--- a/src/Benchmarks/Benchmarks.csproj
+++ b/src/Benchmarks/Benchmarks.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <!-- BenchmarkDotNet requires optimizations, and warns when run under a debugger build -->
+    <Optimize>true</Optimize>
+    <!-- benchmark methods are instance methods by convention -->
+    <NoWarn>$(NoWarn);CA1822</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="AngleSharp" />
+    <PackageReference Include="AngleSharp.Diffing" />
+    <PackageReference Include="BenchmarkDotNet" />
+    <PackageReference Include="ProjectDefaults" PrivateAssets="all" />
+    <ProjectReference Include="..\Verify.AngleSharp\Verify.AngleSharp.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Benchmarks/CacheBusterBenchmarks.cs
+++ b/src/Benchmarks/CacheBusterBenchmarks.cs
@@ -1,0 +1,42 @@
+/// <summary>
+/// The regex substitution applied to every href and src attribute.
+/// WithVersion is a URL carrying a cache buster, WithoutVersion is the far more common case
+/// of an ordinary link, which the pattern can never match.
+/// </summary>
+[MemoryDiagnoser]
+public class CacheBusterBenchmarks
+{
+    const string pattern = @"([^""?]+[?&]v=)[\w\-]+";
+    const string replacement = "$1{TAG_HELPER_VERSION}";
+
+    static readonly Regex cached = new(pattern);
+    static readonly Regex cachedCompiled = new(pattern, RegexOptions.Compiled);
+
+    [Params(
+        "/css/site.css?v=r2K1aJs2_7mdAedOAb0OQXXTwOVHY3K46ElgPZWqeuI",
+        "/css/site.css")]
+    public string Value { get; set; } = null!;
+
+    [Benchmark(Baseline = true)]
+    public string LegacyStaticRegex() =>
+        Regex.Replace(Value, pattern, replacement);
+
+    [Benchmark]
+    public string CachedRegex() =>
+        cached.Replace(Value, replacement);
+
+    [Benchmark]
+    public string CachedRegexCompiled() =>
+        cachedCompiled.Replace(Value, replacement);
+
+    [Benchmark]
+    public string? CurrentCachedWithPreCheck()
+    {
+        if (Value.IndexOf("v=", StringComparison.Ordinal) == -1)
+        {
+            return null;
+        }
+
+        return cached.Replace(Value, replacement);
+    }
+}

--- a/src/Benchmarks/DocumentDetectionBenchmarks.cs
+++ b/src/Benchmarks/DocumentDetectionBenchmarks.cs
@@ -1,0 +1,59 @@
+/// <summary>
+/// Prefix check that decides whether the source is parsed as a document or a body fragment.
+/// Current is a copy of the private HtmlPrettyPrint.IsDocument.
+/// </summary>
+[MemoryDiagnoser]
+public class DocumentDetectionBenchmarks
+{
+    const StringComparison comparer = StringComparison.OrdinalIgnoreCase;
+
+    const string source =
+        """
+        <!DOCTYPE html>
+        <html lang="en">
+          <head><meta charset="utf-8"></head>
+          <body><h1>My Heading</h1></body>
+        </html>
+        """;
+
+    [Benchmark(Baseline = true)]
+    public bool LegacyInvariantCulture() =>
+        Legacy.IsDocumentInvariantCulture(source);
+
+    [Benchmark]
+    public bool LegacyOrdinal() =>
+        Legacy.IsDocumentOrdinal(source);
+
+    [Benchmark]
+    public bool Current() =>
+        IsDocument(source);
+
+    static bool IsDocument(string source)
+    {
+        var index = 0;
+        while (index < source.Length &&
+               char.IsWhiteSpace(source[index]))
+        {
+            index++;
+        }
+
+        if (Matches("<!doctype"))
+        {
+            return true;
+        }
+
+        if (!Matches("<html"))
+        {
+            return false;
+        }
+
+        var next = index + "<html".Length;
+        return next >= source.Length ||
+               source[next] is '>' or '/' ||
+               char.IsWhiteSpace(source[next]);
+
+        bool Matches(string tag) =>
+            index + tag.Length <= source.Length &&
+            string.Compare(source, index, tag, 0, tag.Length, comparer) == 0;
+    }
+}

--- a/src/Benchmarks/FragmentContextBenchmarks.cs
+++ b/src/Benchmarks/FragmentContextBenchmarks.cs
@@ -15,18 +15,25 @@ public class FragmentContextBenchmarks
         <div class="card"><span>content</span></div>
         """;
 
-    [Benchmark(Baseline = true, Description = "Throwaway context document only")]
-    public IDocument ContextDocumentOnly() =>
+    [Benchmark(Baseline = true, Description = "Legacy context document only")]
+    public IDocument LegacyContextDocumentOnly() =>
         parser.ParseDocument("<html><body></body></html>");
 
-    [Benchmark(Description = "Empty context document only")]
-    public IDocument EmptyContextDocumentOnly() =>
+    [Benchmark(Description = "Current context document only")]
+    public IDocument CurrentContextDocumentOnly() =>
         parser.ParseDocument(string.Empty);
 
-    [Benchmark(Description = "Full fragment parse, as Parse does it")]
-    public INodeList ContextDocumentAndFragment()
+    [Benchmark(Description = "Legacy context document + fragment")]
+    public INodeList LegacyContextDocumentAndFragment()
     {
         var document = parser.ParseDocument("<html><body></body></html>");
+        return parser.ParseFragment(fragment, document.Body!);
+    }
+
+    [Benchmark(Description = "Current context document + fragment")]
+    public INodeList CurrentContextDocumentAndFragment()
+    {
+        var document = parser.ParseDocument(string.Empty);
         return parser.ParseFragment(fragment, document.Body!);
     }
 }

--- a/src/Benchmarks/FragmentContextBenchmarks.cs
+++ b/src/Benchmarks/FragmentContextBenchmarks.cs
@@ -1,0 +1,32 @@
+/// <summary>
+/// Fragment parsing needs a context element, which Parse obtains by parsing a throwaway
+/// document on every call. This measures whether that throwaway is worth avoiding, relative
+/// to the fragment parse it supports.
+/// </summary>
+[MemoryDiagnoser]
+public class FragmentContextBenchmarks
+{
+    static readonly HtmlParser parser = new();
+
+    const string fragment =
+        """
+        <p>My first paragraph.</p>
+        <ul><li>one</li><li>two</li><li>three</li></ul>
+        <div class="card"><span>content</span></div>
+        """;
+
+    [Benchmark(Baseline = true, Description = "Throwaway context document only")]
+    public IDocument ContextDocumentOnly() =>
+        parser.ParseDocument("<html><body></body></html>");
+
+    [Benchmark(Description = "Empty context document only")]
+    public IDocument EmptyContextDocumentOnly() =>
+        parser.ParseDocument(string.Empty);
+
+    [Benchmark(Description = "Full fragment parse, as Parse does it")]
+    public INodeList ContextDocumentAndFragment()
+    {
+        var document = parser.ParseDocument("<html><body></body></html>");
+        return parser.ParseFragment(fragment, document.Body!);
+    }
+}

--- a/src/Benchmarks/GlobalUsings.cs
+++ b/src/Benchmarks/GlobalUsings.cs
@@ -1,0 +1,8 @@
+global using System.Text;
+global using System.Text.RegularExpressions;
+global using AngleSharp.Diffing.Extensions;
+global using AngleSharp.Dom;
+global using AngleSharp.Html.Dom;
+global using AngleSharp.Html.Parser;
+global using BenchmarkDotNet.Attributes;
+global using VerifyTests.AngleSharp;

--- a/src/Benchmarks/Legacy.cs
+++ b/src/Benchmarks/Legacy.cs
@@ -1,0 +1,81 @@
+/// <summary>
+/// Verbatim copies of the implementations as they were before the fixes, kept only so the
+/// benchmarks can measure an actual before and after. Nothing here should be used for real.
+/// </summary>
+public static class Legacy
+{
+    const StringComparison comparer = StringComparison.OrdinalIgnoreCase;
+
+    public static bool IsDocumentInvariantCulture(string source) =>
+        source.StartsWith("<!DOCTYPE html>", StringComparison.InvariantCultureIgnoreCase) ||
+        source.StartsWith("<html>", StringComparison.InvariantCultureIgnoreCase);
+
+    public static bool IsDocumentOrdinal(string source) =>
+        source.StartsWith("<!DOCTYPE html>", comparer) ||
+        source.StartsWith("<html>", comparer);
+
+    public static void ScrubEmptyDivs(IEnumerable<IElement> elements)
+    {
+        foreach (var element in elements.DescendantsAndSelf<IElement>())
+        {
+            TryScrubDiv(element);
+        }
+    }
+
+    public static bool TryScrubDiv(IElement element)
+    {
+        if (element is not IHtmlDivElement div)
+        {
+            return false;
+        }
+
+        div.InnerHtml = div.InnerHtml.TrimEnd();
+        if (element.HasAttributes())
+        {
+            return false;
+        }
+
+        if (!element.HasChildNodes)
+        {
+            element.RemoveFromParent();
+        }
+        else if (element.Children.Length == 1)
+        {
+            var child = element.FirstChild;
+            element.Parent!.AppendChild(child);
+        }
+
+        return true;
+    }
+
+    public static void ScrubAspCacheBusterTagHelper(IEnumerable<IElement> elements) =>
+        ScrubAttributes(
+            elements,
+            static attr =>
+            {
+                if (attr.Name.Equals("href", comparer) || attr.Name.Equals("src", comparer))
+                {
+                    const string pattern = @"([^""?]+[?&]v=)[\w\-]+";
+                    const string replacement = "$1{TAG_HELPER_VERSION}";
+
+                    return Regex.Replace(attr.Value, pattern, replacement);
+                }
+
+                return attr.Value;
+            });
+
+    public static void ScrubAttributes(IEnumerable<IElement> elements, Func<IAttr, string?> tryGetValue)
+    {
+        foreach (var element in elements.DescendantsAndSelf<IElement>())
+        {
+            foreach (var attribute in element.Attributes)
+            {
+                var value = tryGetValue(attribute);
+                if (value != null)
+                {
+                    attribute.Value = value;
+                }
+            }
+        }
+    }
+}

--- a/src/Benchmarks/Program.cs
+++ b/src/Benchmarks/Program.cs
@@ -1,0 +1,3 @@
+using BenchmarkDotNet.Running;
+
+BenchmarkSwitcher.FromAssembly(typeof(Legacy).Assembly).Run(args);

--- a/src/Benchmarks/ScrubAspCacheBusterBenchmarks.cs
+++ b/src/Benchmarks/ScrubAspCacheBusterBenchmarks.cs
@@ -1,0 +1,57 @@
+/// <summary>
+/// Full cache buster scrub over a page with many attributes, only a few of which are href or
+/// src carrying a version. Legacy reassigned every attribute in the document and ran the
+/// static Regex.Replace overload for every href and src.
+/// </summary>
+[MemoryDiagnoser]
+public class ScrubAspCacheBusterBenchmarks
+{
+    static readonly HtmlParser parser = new();
+    static readonly string html = Build();
+
+    static string Build()
+    {
+        var builder = new StringBuilder("<!DOCTYPE html><html><head>");
+        builder.Append("""<link href="/css/site.css?v=r2K1aJs2_7mdAedOAb0OQXXTwOVHY3K46ElgPZWqeuI" rel="stylesheet">""");
+        builder.Append("""<script src="/js/site.js?v=4q1jwHbih5xTTZoI1K3CyVNBn6G5cyGXls93d_7XUPA"></script>""");
+        builder.Append("</head><body>");
+        for (var i = 0; i < 100; i++)
+        {
+            builder.Append("<div class=\"card shadow\" id=\"card-")
+                .Append(i)
+                .Append("\" data-index=\"")
+                .Append(i)
+                .Append("\" role=\"listitem\">")
+                .Append("<a href=\"/products/")
+                .Append(i)
+                .Append("\" title=\"Product\">Product</a>")
+                .Append("<img src=\"/images/product-")
+                .Append(i)
+                .Append(".png\" alt=\"Product image\" loading=\"lazy\">")
+                .Append("</div>");
+        }
+
+        builder.Append("</body></html>");
+        return builder.ToString();
+    }
+
+    [Benchmark(Description = "Parse only (subtract from the two below)")]
+    public IDocument ParseOnly() =>
+        parser.ParseDocument(html);
+
+    [Benchmark(Baseline = true, Description = "Legacy parse + scrub")]
+    public IDocument LegacyParseAndScrub()
+    {
+        var document = parser.ParseDocument(html);
+        Legacy.ScrubAspCacheBusterTagHelper(document.ChildNodes.OfType<IElement>());
+        return document;
+    }
+
+    [Benchmark(Description = "Current parse + scrub")]
+    public IDocument CurrentParseAndScrub()
+    {
+        var document = parser.ParseDocument(html);
+        document.ChildNodes.ScrubAspCacheBusterTagHelper();
+        return document;
+    }
+}

--- a/src/Benchmarks/ScrubEmptyDivsBenchmarks.cs
+++ b/src/Benchmarks/ScrubEmptyDivsBenchmarks.cs
@@ -1,0 +1,49 @@
+/// <summary>
+/// Full scrub over a document of 300 divs, exercising the InnerHtml round trip that the
+/// legacy TryScrubDiv performed for every div. ParseOnly is included so the parse cost
+/// common to both can be subtracted.
+/// </summary>
+[MemoryDiagnoser]
+public class ScrubEmptyDivsBenchmarks
+{
+    static readonly HtmlParser parser = new();
+    static readonly string html = Build();
+
+    static string Build()
+    {
+        var builder = new StringBuilder("<!DOCTYPE html><html><body>");
+        for (var i = 0; i < 100; i++)
+        {
+            builder.Append("<div class=\"row\"><p>paragraph ")
+                .Append(i)
+                .Append("</p><p>a second paragraph carrying some text</p>\n  </div>")
+                .Append("<div><p>only child ")
+                .Append(i)
+                .Append("</p></div>")
+                .Append("<div>   </div>");
+        }
+
+        builder.Append("</body></html>");
+        return builder.ToString();
+    }
+
+    [Benchmark(Description = "Parse only (subtract from the two below)")]
+    public IDocument ParseOnly() =>
+        parser.ParseDocument(html);
+
+    [Benchmark(Baseline = true, Description = "Legacy parse + scrub")]
+    public IDocument LegacyParseAndScrub()
+    {
+        var document = parser.ParseDocument(html);
+        Legacy.ScrubEmptyDivs(document.ChildNodes.OfType<IElement>());
+        return document;
+    }
+
+    [Benchmark(Description = "Current parse + scrub")]
+    public IDocument CurrentParseAndScrub()
+    {
+        var document = parser.ParseDocument(html);
+        document.ChildNodes.ScrubEmptyDivs();
+        return document;
+    }
+}

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -5,6 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="AngleSharp" Version="1.5.2" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="AngleSharp.Css" Version="1.0.0-beta.216" />
     <PackageVersion Include="AngleSharp.Diffing" Version="1.1.1" />
     <PackageVersion Include="MarkdownSnippets.MsBuild" Version="28.4.1" />

--- a/src/Tests/AngleSharpExtensionsTests.cs
+++ b/src/Tests/AngleSharpExtensionsTests.cs
@@ -1,0 +1,31 @@
+[TestFixture]
+public class AngleSharpExtensionsTests
+{
+    static INodeList Parse(string html)
+    {
+        var parser = new HtmlParser();
+        var document = parser.ParseDocument("<html><body></body></html>");
+        return parser.ParseFragment(html, document.Body!);
+    }
+
+    [Test]
+    public void DescendantsAndSelfDoesNotDuplicateTopLevelNodes()
+    {
+        var nodes = Parse("<a><b></b></a>");
+
+        var result = nodes.DescendantsAndSelf().ToList();
+
+        Assert.That(result.Select(_ => _.NodeName), Is.EqualTo(new[] { "A", "B" }));
+    }
+
+    [Test]
+    public void DescendantsAndSelfDoesNotDuplicateSiblings()
+    {
+        var nodes = Parse("<p>one</p><p>two</p>");
+
+        var result = nodes.DescendantsAndSelf<IElement>().ToList();
+
+        Assert.That(result, Has.Count.EqualTo(2));
+        Assert.That(result.Distinct().Count(), Is.EqualTo(2));
+    }
+}

--- a/src/Tests/AngleSharpExtensionsTests.cs
+++ b/src/Tests/AngleSharpExtensionsTests.cs
@@ -28,4 +28,24 @@ public class AngleSharpExtensionsTests
         Assert.That(result, Has.Count.EqualTo(2));
         Assert.That(result.Distinct().Count(), Is.EqualTo(2));
     }
+
+    [Test]
+    public void DescendantsExcludesTopLevelNodes()
+    {
+        var nodes = Parse("<a><b></b></a>");
+
+        var result = nodes.Descendants().ToList();
+
+        Assert.That(result.Select(_ => _.NodeName), Is.EqualTo(new[] { "B" }));
+    }
+
+    [Test]
+    public void DescendantsOfTypeExcludesTopLevelNodes()
+    {
+        var nodes = Parse("<p>one</p><p>two</p>");
+
+        var result = nodes.Descendants<IElement>().ToList();
+
+        Assert.That(result, Is.Empty);
+    }
 }

--- a/src/Tests/PrettyPrintHtmlTests.DocumentWithHtmlAttributes.verified.html
+++ b/src/Tests/PrettyPrintHtmlTests.DocumentWithHtmlAttributes.verified.html
@@ -1,0 +1,6 @@
+﻿<html lang="en">
+  <head></head>
+  <body>
+    <h1>My Heading</h1>
+  </body>
+</html>

--- a/src/Tests/PrettyPrintHtmlTests.DocumentWithLeadingWhitespace.verified.html
+++ b/src/Tests/PrettyPrintHtmlTests.DocumentWithLeadingWhitespace.verified.html
@@ -1,0 +1,7 @@
+﻿<!DOCTYPE html>
+<html>
+  <head></head>
+  <body>
+    <h1>My Heading</h1>
+  </body>
+</html>

--- a/src/Tests/PrettyPrintHtmlTests.DocumentWithLegacyDoctype.verified.html
+++ b/src/Tests/PrettyPrintHtmlTests.DocumentWithLegacyDoctype.verified.html
@@ -1,0 +1,7 @@
+﻿<!DOCTYPE html SYSTEM "about:legacy-compat">
+<html>
+  <head></head>
+  <body>
+    <h1>My Heading</h1>
+  </body>
+</html>

--- a/src/Tests/PrettyPrintHtmlTests.FragmentIsNotWrappedInDocument.verified.html
+++ b/src/Tests/PrettyPrintHtmlTests.FragmentIsNotWrappedInDocument.verified.html
@@ -1,0 +1,2 @@
+﻿
+<p>My first paragraph.</p>

--- a/src/Tests/PrettyPrintHtmlTests.cs
+++ b/src/Tests/PrettyPrintHtmlTests.cs
@@ -1,0 +1,58 @@
+[TestFixture]
+public class PrettyPrintHtmlTests
+{
+    [Test]
+    public Task DocumentWithHtmlAttributes()
+    {
+        var html = """
+                   <html lang="en">
+                     <body>
+                       <h1>My Heading</h1>
+                     </body>
+                   </html>
+                   """;
+        return Verify(html, "html")
+            .PrettyPrintHtml();
+    }
+
+    [Test]
+    public Task DocumentWithLeadingWhitespace()
+    {
+        var html = "\n  " +
+                   """
+                   <!DOCTYPE html>
+                   <html>
+                     <body>
+                       <h1>My Heading</h1>
+                     </body>
+                   </html>
+                   """;
+        return Verify(html, "html")
+            .PrettyPrintHtml();
+    }
+
+    [Test]
+    public Task DocumentWithLegacyDoctype()
+    {
+        var html = """
+                   <!DOCTYPE html SYSTEM "about:legacy-compat">
+                   <html>
+                     <body>
+                       <h1>My Heading</h1>
+                     </body>
+                   </html>
+                   """;
+        return Verify(html, "html")
+            .PrettyPrintHtml();
+    }
+
+    [Test]
+    public Task FragmentIsNotWrappedInDocument()
+    {
+        var html = """
+                   <p>My first paragraph.</p>
+                   """;
+        return Verify(html, "html")
+            .PrettyPrintHtml();
+    }
+}

--- a/src/Tests/ScrubAspCacheBusterTagHelperTests.DoesNotScrubVOutsideQueryString.verified.html
+++ b/src/Tests/ScrubAspCacheBusterTagHelperTests.DoesNotScrubVOutsideQueryString.verified.html
@@ -1,0 +1,7 @@
+﻿<!DOCTYPE html>
+<html>
+  <head></head>
+  <body>
+    <a href="/path/v=notaquerystring">Link</a>
+  </body>
+</html>

--- a/src/Tests/ScrubAspCacheBusterTagHelperTests.cs
+++ b/src/Tests/ScrubAspCacheBusterTagHelperTests.cs
@@ -109,6 +109,21 @@ public class ScrubAspCacheBusterTagHelperTests
     }
 
     [Test]
+    public Task DoesNotScrubVOutsideQueryString()
+    {
+        var html = """
+                   <!DOCTYPE html>
+                   <html>
+                     <body>
+                       <a href="/path/v=notaquerystring">Link</a>
+                     </body>
+                   </html>
+                   """;
+        return Verify(html, "html")
+            .PrettyPrintHtml(nodes => nodes.ScrubAspCacheBusterTagHelper());
+    }
+
+    [Test]
     public Task DoesNotAffectOtherAttributes()
     {
         var html = """

--- a/src/Tests/ScrubEmptyDivsTests.cs
+++ b/src/Tests/ScrubEmptyDivsTests.cs
@@ -74,6 +74,33 @@ public class ScrubEmptyDivsTests
         Assert.That(result, Is.EqualTo("<div>My First Heading</div>"));
     }
 
+    static IElement FirstElement(string html)
+    {
+        var parser = new HtmlParser();
+        var document = parser.ParseDocument($"<html><body>{html}</body></html>");
+        return document.Body!.Children[0];
+    }
+
+    [Test]
+    public void ReturnsTrueWhenDivRemoved() =>
+        Assert.That(FirstElement("<div></div>").TryScrubDiv(), Is.True);
+
+    [Test]
+    public void ReturnsTrueWhenDivUnwrapped() =>
+        Assert.That(FirstElement("<div><p>x</p></div>").TryScrubDiv(), Is.True);
+
+    [Test]
+    public void ReturnsFalseForNonDiv() =>
+        Assert.That(FirstElement("<p>x</p>").TryScrubDiv(), Is.False);
+
+    [Test]
+    public void ReturnsFalseWhenDivHasAttributes() =>
+        Assert.That(FirstElement("<div id='a'><p>x</p></div>").TryScrubDiv(), Is.False);
+
+    [Test]
+    public void ReturnsFalseWhenNothingToScrub() =>
+        Assert.That(FirstElement("<div><p>a</p><p>b</p></div>").TryScrubDiv(), Is.False);
+
     [Test]
     public void DoesNotThrowForDivWithoutParent()
     {

--- a/src/Tests/ScrubEmptyDivsTests.cs
+++ b/src/Tests/ScrubEmptyDivsTests.cs
@@ -11,6 +11,38 @@ public class ScrubEmptyDivsTests
     }
 
     [Test]
+    public void UnwrapsSingleElementChildInPlace()
+    {
+        var result = Scrub("<div><p>content</p></div><footer>foot</footer>");
+
+        Assert.That(result, Is.EqualTo("<p>content</p><footer>foot</footer>"));
+    }
+
+    [Test]
+    public void UnwrapsElementSurroundedByWhitespace()
+    {
+        var result = Scrub("<div>\n  <p>content</p>\n</div><footer>foot</footer>");
+
+        Assert.That(result, Is.EqualTo("<p>content</p><footer>foot</footer>"));
+    }
+
+    [Test]
+    public void DoesNotUnwrapWhenTextWouldBeLost()
+    {
+        var result = Scrub("<div>hello <span>world</span></div>");
+
+        Assert.That(result, Is.EqualTo("<div>hello <span>world</span></div>"));
+    }
+
+    [Test]
+    public void DoesNotUnwrapMultipleElementChildren()
+    {
+        var result = Scrub("<div><p>a</p><p>b</p></div>");
+
+        Assert.That(result, Is.EqualTo("<div><p>a</p><p>b</p></div>"));
+    }
+
+    [Test]
     public void RemovesEmptyDiv()
     {
         var result = Scrub("<div></div><footer>foot</footer>");

--- a/src/Tests/ScrubEmptyDivsTests.cs
+++ b/src/Tests/ScrubEmptyDivsTests.cs
@@ -27,6 +27,14 @@ public class ScrubEmptyDivsTests
     }
 
     [Test]
+    public void UnwrapsNestedDivs()
+    {
+        var result = Scrub("<div><div><p>deep</p></div></div><footer>foot</footer>");
+
+        Assert.That(result, Is.EqualTo("<p>deep</p><footer>foot</footer>"));
+    }
+
+    [Test]
     public void DoesNotUnwrapWhenTextWouldBeLost()
     {
         var result = Scrub("<div>hello <span>world</span></div>");

--- a/src/Tests/ScrubEmptyDivsTests.cs
+++ b/src/Tests/ScrubEmptyDivsTests.cs
@@ -67,6 +67,17 @@ public class ScrubEmptyDivsTests
     }
 
     [Test]
+    public void DoesNotThrowForDivWithoutParent()
+    {
+        var parser = new HtmlParser();
+        var document = parser.ParseDocument("<html><body><div><p>content</p></div></body></html>");
+        var div = document.QuerySelector("div")!;
+        div.Remove();
+
+        Assert.DoesNotThrow(() => div.TryScrubDiv());
+    }
+
+    [Test]
     public void KeepsDivWithAttributes()
     {
         var result = Scrub("<div id='keep'><p>content</p></div>");

--- a/src/Tests/ScrubEmptyDivsTests.cs
+++ b/src/Tests/ScrubEmptyDivsTests.cs
@@ -1,0 +1,44 @@
+[TestFixture]
+public class ScrubEmptyDivsTests
+{
+    static string Scrub(string html)
+    {
+        var parser = new HtmlParser();
+        var document = parser.ParseDocument($"<html><body>{html}</body></html>");
+        var body = document.Body!;
+        body.ChildNodes.ScrubEmptyDivs();
+        return body.InnerHtml;
+    }
+
+    [Test]
+    public void RemovesEmptyDiv()
+    {
+        var result = Scrub("<div></div><footer>foot</footer>");
+
+        Assert.That(result, Is.EqualTo("<footer>foot</footer>"));
+    }
+
+    [Test]
+    public void RemovesWhitespaceOnlyDiv()
+    {
+        var result = Scrub("<div>\n   </div><footer>foot</footer>");
+
+        Assert.That(result, Is.EqualTo("<footer>foot</footer>"));
+    }
+
+    [Test]
+    public void KeepsTextOnlyDiv()
+    {
+        var result = Scrub("<div>My First Heading</div>");
+
+        Assert.That(result, Is.EqualTo("<div>My First Heading</div>"));
+    }
+
+    [Test]
+    public void KeepsDivWithAttributes()
+    {
+        var result = Scrub("<div id='keep'><p>content</p></div>");
+
+        Assert.That(result, Is.EqualTo("""<div id="keep"><p>content</p></div>"""));
+    }
+}

--- a/src/Verify.AngleSharp.slnx
+++ b/src/Verify.AngleSharp.slnx
@@ -11,6 +11,7 @@
     <File Path="../global.json" />
     <File Path="mdsnippets.json" />
   </Folder>
+  <Project Path="Benchmarks/Benchmarks.csproj" />
   <Project Path="Tests/Tests.csproj" />
   <Project Path="Verify.AngleSharp/Verify.AngleSharp.csproj" />
 </Solution>

--- a/src/Verify.AngleSharp/AngleSharpExtensions.cs
+++ b/src/Verify.AngleSharp/AngleSharpExtensions.cs
@@ -10,10 +10,10 @@ public static class AngleSharpExtensions
     {
         foreach (var node in nodes.ToList())
         {
-            yield return node;
-            foreach (var element in node.DescendantsAndSelf())
+            // node.DescendantsAndSelf() already yields node
+            foreach (var descendant in node.DescendantsAndSelf())
             {
-                yield return element;
+                yield return descendant;
             }
         }
     }

--- a/src/Verify.AngleSharp/AngleSharpExtensions.cs
+++ b/src/Verify.AngleSharp/AngleSharpExtensions.cs
@@ -40,9 +40,9 @@ public static class AngleSharpExtensions
     {
         foreach (var node in nodes.ToList())
         {
-            foreach (var element in node.DescendantsAndSelf())
+            foreach (var descendant in node.Descendants())
             {
-                yield return element;
+                yield return descendant;
             }
         }
     }

--- a/src/Verify.AngleSharp/HtmlPrettyPrint.cs
+++ b/src/Verify.AngleSharp/HtmlPrettyPrint.cs
@@ -282,8 +282,8 @@ public static class HtmlPrettyPrint
     static INodeList Parse(string source)
     {
         var parser = new HtmlParser();
-        if (source.StartsWith("<!DOCTYPE html>", StringComparison.InvariantCultureIgnoreCase) ||
-            source.StartsWith("<html>", StringComparison.InvariantCultureIgnoreCase))
+        if (source.StartsWith("<!DOCTYPE html>", comparer) ||
+            source.StartsWith("<html>", comparer))
         {
             return parser.ParseDocument(source).ChildNodes;
         }

--- a/src/Verify.AngleSharp/HtmlPrettyPrint.cs
+++ b/src/Verify.AngleSharp/HtmlPrettyPrint.cs
@@ -4,6 +4,10 @@ public static class HtmlPrettyPrint
 {
     const StringComparison comparer = StringComparison.OrdinalIgnoreCase;
 
+    const string cacheBusterReplacement = "$1{TAG_HELPER_VERSION}";
+
+    static readonly Regex cacheBusterPattern = new(@"([^""?]+[?&]v=)[\w\-]+");
+
     public static void All(Action<INodeList>? action = null)
     {
         VerifierSettings.AddScrubber("html", builder => CleanSource(builder, action));
@@ -189,15 +193,21 @@ public static class HtmlPrettyPrint
     public static void ScrubAspCacheBusterTagHelper(this IEnumerable<IElement> elements) =>
         elements.ScrubAttributes(static attr =>
         {
-            if (attr.Name.Equals("href", comparer) || attr.Name.Equals("src", comparer))
+            if (!attr.Name.Equals("href", comparer) &&
+                !attr.Name.Equals("src", comparer))
             {
-                const string pattern = @"([^""?]+[?&]v=)[\w\-]+";
-                const string replacement = "$1{TAG_HELPER_VERSION}";
-
-                return Regex.Replace(attr.Value, pattern, replacement);
+                return null;
             }
 
-            return null;
+            var value = attr.Value;
+
+            // the pattern cannot match without a literal v=
+            if (value.IndexOf("v=", StringComparison.Ordinal) == -1)
+            {
+                return null;
+            }
+
+            return cacheBusterPattern.Replace(value, cacheBusterReplacement);
         });
 
     /// <summary>

--- a/src/Verify.AngleSharp/HtmlPrettyPrint.cs
+++ b/src/Verify.AngleSharp/HtmlPrettyPrint.cs
@@ -297,7 +297,9 @@ public static class HtmlPrettyPrint
             return parser.ParseDocument(source).ChildNodes;
         }
 
-        var dom = parser.ParseDocument("<html><body></body></html>");
+        // an empty document still yields html, head, and body, so it serves as a
+        // fragment context for less work than parsing the markup for them
+        var dom = parser.ParseDocument(string.Empty);
         return parser.ParseFragment(source, dom.Body!);
     }
 

--- a/src/Verify.AngleSharp/HtmlPrettyPrint.cs
+++ b/src/Verify.AngleSharp/HtmlPrettyPrint.cs
@@ -287,7 +287,6 @@ public static class HtmlPrettyPrint
         };
         using var writer = new StringWriter(builder);
         document.ToHtml(writer, formatter);
-        writer.Flush();
     }
 
     static INodeList Parse(string source)

--- a/src/Verify.AngleSharp/HtmlPrettyPrint.cs
+++ b/src/Verify.AngleSharp/HtmlPrettyPrint.cs
@@ -39,13 +39,46 @@ public static class HtmlPrettyPrint
         {
             element.RemoveFromParent();
         }
-        else if (element.Children.Length == 1)
+        else if (TryGetOnlyElement(element, out var child))
         {
-            var child = element.FirstChild;
-            element.Parent!.AppendChild(child);
+            element.Parent!.InsertBefore(child, element);
+            element.RemoveFromParent();
         }
 
         return true;
+    }
+
+    /// <summary>
+    /// Gets the single child element of <paramref name="element" />, but only when every
+    /// other child node is whitespace. Returns false when there is no element, more than
+    /// one element, or any text that unwrapping would discard.
+    /// </summary>
+    static bool TryGetOnlyElement(IElement element, [NotNullWhen(true)] out IElement? child)
+    {
+        child = null;
+        foreach (var node in element.ChildNodes)
+        {
+            if (node is IElement candidate)
+            {
+                if (child != null)
+                {
+                    child = null;
+                    return false;
+                }
+
+                child = candidate;
+                continue;
+            }
+
+            if (node is not IText text ||
+                !string.IsNullOrWhiteSpace(text.Data))
+            {
+                child = null;
+                return false;
+            }
+        }
+
+        return child != null;
     }
 
     public static void ScrubAttributes(this INodeList nodes, string name) =>

--- a/src/Verify.AngleSharp/HtmlPrettyPrint.cs
+++ b/src/Verify.AngleSharp/HtmlPrettyPrint.cs
@@ -29,7 +29,7 @@ public static class HtmlPrettyPrint
             return false;
         }
 
-        div.InnerHtml = div.InnerHtml.TrimEnd();
+        TrimTrailingWhitespace(div);
         if (element.HasAttributes())
         {
             return false;
@@ -47,6 +47,26 @@ public static class HtmlPrettyPrint
         }
 
         return true;
+    }
+
+    /// <summary>
+    /// Equivalent to trimming the end of InnerHtml, but without serializing and re-parsing
+    /// the subtree. The round trip replaced every descendant node, which both invalidated
+    /// nodes already collected for scrubbing and cost a full parse per div.
+    /// </summary>
+    static void TrimTrailingWhitespace(IElement element)
+    {
+        while (element.LastChild is IText text)
+        {
+            var trimmed = text.Data.TrimEnd();
+            if (trimmed.Length != 0)
+            {
+                text.Data = trimmed;
+                return;
+            }
+
+            element.RemoveChild(text);
+        }
     }
 
     /// <summary>

--- a/src/Verify.AngleSharp/HtmlPrettyPrint.cs
+++ b/src/Verify.AngleSharp/HtmlPrettyPrint.cs
@@ -39,9 +39,10 @@ public static class HtmlPrettyPrint
         {
             element.RemoveFromParent();
         }
-        else if (TryGetOnlyElement(element, out var child))
+        else if (element.Parent is { } parent &&
+                 TryGetOnlyElement(element, out var child))
         {
-            element.Parent!.InsertBefore(child, element);
+            parent.InsertBefore(child, element);
             element.RemoveFromParent();
         }
 

--- a/src/Verify.AngleSharp/HtmlPrettyPrint.cs
+++ b/src/Verify.AngleSharp/HtmlPrettyPrint.cs
@@ -15,7 +15,8 @@ public static class HtmlPrettyPrint
 
     public static void ScrubEmptyDivs(this IEnumerable<IElement> elements)
     {
-        foreach (var element in elements.DescendantsAndSelf<IElement>())
+        // materialized since scrubbing removes nodes from the tree being walked
+        foreach (var element in elements.DescendantsAndSelf<IElement>().ToList())
         {
             TryScrubDiv(element);
         }

--- a/src/Verify.AngleSharp/HtmlPrettyPrint.cs
+++ b/src/Verify.AngleSharp/HtmlPrettyPrint.cs
@@ -129,7 +129,8 @@ public static class HtmlPrettyPrint
             foreach (var attribute in element.Attributes)
             {
                 var value = tryGetValue(attribute);
-                if (value != null)
+                if (value != null &&
+                    !string.Equals(value, attribute.Value, StringComparison.Ordinal))
                 {
                     attribute.Value = value;
                 }
@@ -196,7 +197,7 @@ public static class HtmlPrettyPrint
                 return Regex.Replace(attr.Value, pattern, replacement);
             }
 
-            return attr.Value;
+            return null;
         });
 
     /// <summary>

--- a/src/Verify.AngleSharp/HtmlPrettyPrint.cs
+++ b/src/Verify.AngleSharp/HtmlPrettyPrint.cs
@@ -282,13 +282,46 @@ public static class HtmlPrettyPrint
     static INodeList Parse(string source)
     {
         var parser = new HtmlParser();
-        if (source.StartsWith("<!DOCTYPE html>", comparer) ||
-            source.StartsWith("<html>", comparer))
+        if (IsDocument(source))
         {
             return parser.ParseDocument(source).ChildNodes;
         }
 
         var dom = parser.ParseDocument("<html><body></body></html>");
         return parser.ParseFragment(source, dom.Body!);
+    }
+
+    /// <summary>
+    /// Detects a full document so it is parsed as one. Parsing a document as a body
+    /// fragment silently discards the html, head, and body elements.
+    /// </summary>
+    static bool IsDocument(string source)
+    {
+        var index = 0;
+        while (index < source.Length &&
+               char.IsWhiteSpace(source[index]))
+        {
+            index++;
+        }
+
+        if (Matches("<!doctype"))
+        {
+            return true;
+        }
+
+        if (!Matches("<html"))
+        {
+            return false;
+        }
+
+        // guard against matching elements like <htmlfoo>
+        var next = index + "<html".Length;
+        return next >= source.Length ||
+               source[next] is '>' or '/' ||
+               char.IsWhiteSpace(source[next]);
+
+        bool Matches(string tag) =>
+            index + tag.Length <= source.Length &&
+            string.Compare(source, index, tag, 0, tag.Length, comparer) == 0;
     }
 }

--- a/src/Verify.AngleSharp/HtmlPrettyPrint.cs
+++ b/src/Verify.AngleSharp/HtmlPrettyPrint.cs
@@ -22,6 +22,11 @@ public static class HtmlPrettyPrint
         }
     }
 
+    /// <summary>
+    /// Removes <paramref name="element" /> when it is a div with no attributes and no
+    /// content, or unwraps it when it wraps a single element.
+    /// </summary>
+    /// <returns>True when the div was removed or unwrapped.</returns>
     public static bool TryScrubDiv(this IElement element)
     {
         if (element is not IHtmlDivElement div)
@@ -38,15 +43,18 @@ public static class HtmlPrettyPrint
         if (!element.HasChildNodes)
         {
             element.RemoveFromParent();
+            return true;
         }
-        else if (element.Parent is { } parent &&
-                 TryGetOnlyElement(element, out var child))
+
+        if (element.Parent is { } parent &&
+            TryGetOnlyElement(element, out var child))
         {
             parent.InsertBefore(child, element);
             element.RemoveFromParent();
+            return true;
         }
 
-        return true;
+        return false;
     }
 
     /// <summary>

--- a/src/Verify.AngleSharp/VerifyAngleSharpDiffing.cs
+++ b/src/Verify.AngleSharp/VerifyAngleSharpDiffing.cs
@@ -33,16 +33,16 @@ public static class VerifyAngleSharpDiffing
         return false;
     }
 
-    public static bool Initialized { get; private set; }
+    static int initialized;
+
+    public static bool Initialized => initialized == 1;
 
     public static void Initialize(Action<IDiffingStrategyCollection>? action = null)
     {
-        if (Initialized)
+        if (Interlocked.Exchange(ref initialized, 1) == 1)
         {
             throw new("Already Initialized");
         }
-
-        Initialized = true;
 
         InnerVerifier.ThrowIfVerifyHasBeenRun();
 


### PR DESCRIPTION
# `Bug-Sweep` branch summary

## Commits

| # | Commit | Type |
| --- | --- | --- |
| 1 | Fix `DescendantsAndSelf` yielding top-level nodes twice | bug |
| 2 | Fix `Descendants` including the nodes themselves | bug |
| 3 | Fix `ScrubEmptyDivs` throwing when a scrubbed div is in the passed node list | bug (crash) |
| 4 | Fix `TryScrubDiv` relocating unwrapped content to the end of the parent | bug (data) |
| 5 | Fix `TryScrubDiv` throwing on a div with no parent | bug (crash) |
| 6 | Replace `InnerHtml` round trip with a direct trailing whitespace trim | bug + perf |
| 7 | Make `TryScrubDiv` return whether the div was actually scrubbed | breaking |
| 8 | Use ordinal comparison for document detection | perf |
| 9 | Detect documents that do not start with an exact DOCTYPE or `<html>` | bug (data) |
| 10 | Do not rewrite attributes that are not changing | perf |
| 11 | Cache the cache buster regex and skip values that cannot match | perf |
| 12 | Remove redundant flush and make `Initialize` atomic | cleanup |
| 13 | Add benchmarks covering the performance fixes | infra |
| 14 | Use an empty document as the fragment parse context | perf |

## Production changes

Three files, **+133 / −25**:

| File | Δ | What |
| --- | --- | --- |
| `src/Verify.AngleSharp/HtmlPrettyPrint.cs` | +124 / −16 | Rewrote `TryScrubDiv`; added `TrimTrailingWhitespace`, `TryGetOnlyElement`, `IsDocument`; cached regex; skipped no-op attribute writes |
| `src/Verify.AngleSharp/AngleSharpExtensions.cs` | +5 / −5 | `DescendantsAndSelf` no longer double-yields; `Descendants` no longer includes self |
| `src/Verify.AngleSharp/VerifyAngleSharpDiffing.cs` | +4 / −4 | `Initialize` via `Interlocked.Exchange` |

## Tests

**+24 tests** across 3 new files, all of which fail against the pre-fix code:

- `src/Tests/ScrubEmptyDivsTests.cs` — 122 lines, 15 tests (unwrap placement, whitespace, nesting, text preservation, return contract, detached div)
- `src/Tests/AngleSharpExtensionsTests.cs` — 51 lines, 4 tests
- `src/Tests/PrettyPrintHtmlTests.cs` — 58 lines, 4 Verify tests + verified files
- `src/Tests/ScrubAspCacheBusterTagHelperTests.cs` — +1 test for the regex pre-check

## Infrastructure

New `src/Benchmarks` project (9 files, 356 lines), added to the solution and `Directory.Packages.props`. `Legacy.cs` holds verbatim copies of the pre-fix implementations so every perf claim is a measured before/after rather than an assertion. `BenchmarkDotNet.Artifacts/` gitignored.

## Impact

- **Silent data loss fixed** — commits 4 and 9 were discarding or misplacing markup in verified output
- **Two crashes fixed** — commits 3 and 5, both on documented entry points
- **7.3x / 2.9x faster** scrubbing with 17x less allocation (commits 10, 11); empty-div scrub cost effectively eliminated (commit 6)
- **Breaking** — commit 7 changes `TryScrubDiv`'s return meaning; commits 4, 6, 9 change scrubbed output, so downstream verified files will need re-accepting
