### PR TITLE
Stop pretty printing from rewriting content

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
   <PropertyGroup>
     <NoWarn>CS1591;CS0649;NU1608;NU1109</NoWarn>
-    <Version>5.0.0</Version>
+    <Version>5.1.0</Version>
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <LangVersion>preview</LangVersion>
     <PackageTags>AngleSharp, Verify</PackageTags>

--- a/src/Tests/PrettyPrintHtmlTests.FragmentOpeningWithText.verified.html
+++ b/src/Tests/PrettyPrintHtmlTests.FragmentOpeningWithText.verified.html
@@ -1,0 +1,2 @@
+﻿Some text
+<b>then an element</b>

--- a/src/Tests/PrettyPrintHtmlTests.PreservesPreformattedText.verified.html
+++ b/src/Tests/PrettyPrintHtmlTests.PreservesPreformattedText.verified.html
@@ -1,0 +1,6 @@
+﻿
+<div>
+  <pre>SELECT [e].[Name]
+FROM [Employees] AS [e]
+WHERE [e].[Active] = 1</pre>
+</div>

--- a/src/Tests/PrettyPrintHtmlTests.PreservesTextareaAndScript.verified.html
+++ b/src/Tests/PrettyPrintHtmlTests.PreservesTextareaAndScript.verified.html
@@ -1,0 +1,11 @@
+﻿
+<div>
+  <textarea>line one
+line two</textarea>
+  <script>
+if (x) {
+  go();
+}
+
+  </script>
+</div>

--- a/src/Tests/PrettyPrintHtmlTests.TableCellFragment.verified.html
+++ b/src/Tests/PrettyPrintHtmlTests.TableCellFragment.verified.html
@@ -1,0 +1,3 @@
+﻿
+<td>Aaron</td>
+<td>FullTime</td>

--- a/src/Tests/PrettyPrintHtmlTests.TableRowFragment.verified.html
+++ b/src/Tests/PrettyPrintHtmlTests.TableRowFragment.verified.html
@@ -1,0 +1,5 @@
+﻿
+<tr>
+  <td>Aaron</td>
+  <td>FullTime</td>
+</tr>

--- a/src/Tests/PrettyPrintHtmlTests.TableSectionFragment.verified.html
+++ b/src/Tests/PrettyPrintHtmlTests.TableSectionFragment.verified.html
@@ -1,0 +1,11 @@
+﻿
+<thead>
+  <tr>
+    <th>Name</th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td>Aaron</td>
+  </tr>
+</tbody>

--- a/src/Tests/PrettyPrintHtmlTests.cs
+++ b/src/Tests/PrettyPrintHtmlTests.cs
@@ -55,4 +55,77 @@ public class PrettyPrintHtmlTests
         return Verify(html, "html")
             .PrettyPrintHtml();
     }
+
+    // Indenting the content of a pre rewrites what it says. The formatter is told to leave the
+    // elements whose whitespace is significant alone, so the text survives the round trip.
+    [Test]
+    public Task PreservesPreformattedText()
+    {
+        var html = """
+                   <div><pre>SELECT [e].[Name]
+                   FROM [Employees] AS [e]
+                   WHERE [e].[Active] = 1</pre></div>
+                   """;
+        return Verify(html, "html")
+            .PrettyPrintHtml();
+    }
+
+    [Test]
+    public Task PreservesTextareaAndScript()
+    {
+        var html = """
+                   <div><textarea>line one
+                   line two</textarea><script>
+                   if (x) {
+                     go();
+                   }
+                   </script></div>
+                   """;
+        return Verify(html, "html")
+            .PrettyPrintHtml();
+    }
+
+    // A table fragment is what an innerHTML capture of a table yields. Parsed against body — where a
+    // table tag is not recognised — the tags would be dropped and only the cell text would survive.
+    [Test]
+    public Task TableSectionFragment()
+    {
+        var html = """
+                   <thead><tr><th>Name</th></tr></thead><tbody><tr><td>Aaron</td></tr></tbody>
+                   """;
+        return Verify(html, "html")
+            .PrettyPrintHtml();
+    }
+
+    [Test]
+    public Task TableRowFragment()
+    {
+        var html = """
+                   <tr><td>Aaron</td><td>FullTime</td></tr>
+                   """;
+        return Verify(html, "html")
+            .PrettyPrintHtml();
+    }
+
+    [Test]
+    public Task TableCellFragment()
+    {
+        var html = """
+                   <td>Aaron</td><td>FullTime</td>
+                   """;
+        return Verify(html, "html")
+            .PrettyPrintHtml();
+    }
+
+    // The leading tag decides the parse context, so one that needs no special context still parses
+    // against body — including a fragment that opens with text rather than a tag.
+    [Test]
+    public Task FragmentOpeningWithText()
+    {
+        var html = """
+                   Some text <b>then an element</b>
+                   """;
+        return Verify(html, "html")
+            .PrettyPrintHtml();
+    }
 }

--- a/src/Verify.AngleSharp/HtmlPrettyPrint.cs
+++ b/src/Verify.AngleSharp/HtmlPrettyPrint.cs
@@ -1,4 +1,4 @@
-﻿namespace VerifyTests.AngleSharp;
+namespace VerifyTests.AngleSharp;
 
 public static class HtmlPrettyPrint
 {
@@ -7,6 +7,25 @@ public static class HtmlPrettyPrint
     const string cacheBusterReplacement = "$1{TAG_HELPER_VERSION}";
 
     static readonly Regex cacheBusterPattern = new(@"([^""?]+[?&]v=)[\w\-]+");
+
+    /// <summary>
+    /// Elements rendered as white-space:pre, where the text is content rather than layout: indenting
+    /// inside one rewrites what the document says rather than how it reads. Script and style are not
+    /// here — the formatter already emits their raw-text bodies as they stand.
+    /// </summary>
+    static readonly string[] preformatted =
+    [
+        "pre",
+        "textarea",
+        "listing",
+        "plaintext"
+    ];
+
+    /// <summary>
+    /// Stands in for a preformatted element while the document is formatted around it. Letters and
+    /// digits only, so it passes through text escaping as written.
+    /// </summary>
+    const string preformattedPlaceholder = "VerifyAngleSharpPreformatted";
 
     public static void All(Action<INodeList>? action = null)
     {
@@ -279,14 +298,69 @@ public static class HtmlPrettyPrint
         var document = Parse(source);
         action?.Invoke(document);
 
+        // Lifted out before formatting and put back after: the formatter indents the content of
+        // every element it walks, which for these rewrites the content rather than the layout.
+        var preserved = Detach(document);
+
         builder.Clear();
         var formatter = new PrettyMarkupFormatter
         {
             Indentation = "  ",
             NewLine = "\n"
         };
-        using var writer = new StringWriter(builder);
-        document.ToHtml(writer, formatter);
+        using (var writer = new StringWriter(builder))
+        {
+            document.ToHtml(writer, formatter);
+        }
+
+        for (var index = 0; index < preserved.Count; index++)
+        {
+            builder.Replace(Placeholder(index), preserved[index]);
+        }
+    }
+
+    /// <summary>
+    /// Swaps the content of each preformatted element for a placeholder, returning the markup each
+    /// stood for. The element keeps its place, so the document is laid out exactly as it would have
+    /// been; only what is inside is held back, to go in again untouched.
+    /// </summary>
+    static List<string> Detach(INodeList nodes)
+    {
+        var preserved = new List<string>();
+        foreach (var element in nodes.DescendantsAndSelf<IElement>())
+        {
+            // The outermost of a nest is enough: its content is taken whole, inner ones included.
+            if (!IsPreformatted(element) ||
+                InsidePreformatted(element) ||
+                !element.HasChildNodes)
+            {
+                continue;
+            }
+
+            preserved.Add(element.InnerHtml);
+            element.TextContent = Placeholder(preserved.Count - 1);
+        }
+
+        return preserved;
+    }
+
+    static string Placeholder(int index) =>
+        $"{preformattedPlaceholder}{index}";
+
+    static bool IsPreformatted(IElement element) =>
+        preformatted.Contains(element.LocalName, StringComparer.OrdinalIgnoreCase);
+
+    static bool InsidePreformatted(IElement element)
+    {
+        for (var parent = element.ParentElement; parent is not null; parent = parent.ParentElement)
+        {
+            if (IsPreformatted(parent))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     static INodeList Parse(string source)
@@ -300,7 +374,62 @@ public static class HtmlPrettyPrint
         // an empty document still yields html, head, and body, so it serves as a
         // fragment context for less work than parsing the markup for them
         var dom = parser.ParseDocument(string.Empty);
-        return parser.ParseFragment(source, dom.Body!);
+        return parser.ParseFragment(source, FragmentContext(dom, source));
+    }
+
+    /// <summary>
+    /// The element a fragment is parsed against. Body suits almost everything, but the table tags are
+    /// only recognised inside a table: against body the tree construction rules discard them and keep
+    /// their text, so a fragment of table rows would come back with every tag gone.
+    /// </summary>
+    static IElement FragmentContext(IHtmlDocument dom, string source)
+    {
+        var context = FirstTag(source) switch
+        {
+            "caption" or "colgroup" or "tbody" or "tfoot" or "thead" => "table",
+            // A row against a table would gain the tbody the parser implies around it, so the section
+            // is the context rather than the table itself.
+            "tr" => "tbody",
+            "td" or "th" => "tr",
+            "col" => "colgroup",
+            _ => null
+        };
+
+        if (context is null)
+        {
+            return dom.Body!;
+        }
+
+        return dom.CreateElement(context);
+    }
+
+    /// <summary>
+    /// The name of the first element the source opens, lowercased, or null when it opens with none.
+    /// </summary>
+    static string? FirstTag(string source)
+    {
+        var start = source.IndexOf('<');
+        if (start == -1)
+        {
+            return null;
+        }
+
+        var index = start + 1;
+        var end = index;
+        while (end < source.Length &&
+               char.IsLetterOrDigit(source[end]))
+        {
+            end++;
+        }
+
+        if (end == index)
+        {
+            return null;
+        }
+
+        return source
+            .Substring(index, end - index)
+            .ToLowerInvariant();
     }
 
     /// <summary>


### PR DESCRIPTION
Two ways PrettyPrintHtml changed what a document said rather than how it read.

Preformatted text was reflowed. The formatter indents the content of every element it walks, so a pre came back with its line breaks collapsed to spaces — a snapshot of SQL, or of anything else laid out by its own whitespace, was wrong in a way nothing downstream could recover. Each preformatted element's content is now lifted out before formatting and put back after, so the element still takes the place and indentation it would have while its content survives untouched. PrettyMarkupFormatter's own preserveTextFormatting overload is not used: it keeps the line breaks but still indents each continuation line, which is the same class of change. Script and style are not in the set — the formatter already emits their raw-text bodies as they stand, and including them reflowed the whitespace around them.

Table fragments lost every tag. Anything that is not a whole document was parsed against body, where the tree construction rules do not recognise a table tag and discard it — so the innerHTML of a table came back as the concatenated text of its cells, with no error and no tags. The parse context is now taken from the fragment's leading tag: table sections against a table, cells against a row, columns against a colgroup. A row parses against a tbody rather than a table so the parser does not insert the tbody it would otherwise imply, which would add markup that was never in the input.